### PR TITLE
Forward arguments to MqttClient

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -60,7 +60,15 @@ Adaptor.prototype.disconnect = function(callback) {
  * @publish
  */
 Adaptor.prototype.subscribe = function(topic) {
-  this.client.subscribe(topic);
+  var args = Array.prototype.slice.call(arguments);
+  if (args.length > 1) {
+    mqtt.MqttClient.prototype.subscribe.apply(this.client, args);
+  }
+  else {
+    this.client.subscribe(topic);
+  }
+
+
 };
 
 /**


### PR DESCRIPTION
client.subscribe did not fire callback after subscribed, so forward the rest arguments to the MqttClient if got more than one argument.