### PR TITLE
Added ability to set the mqtt client id

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -20,6 +20,9 @@ var Adaptor = module.exports = function Adaptor(opts) {
   this.additionalOpts = {};
   this.additionalOpts.username = opts.username;
   this.additionalOpts.password = opts.password;
+  if (opts.clientId) { 
+    this.additionalOpts.clientId = opts.clientId; 
+  }
 
   this.events = [
 


### PR DESCRIPTION
Now you can set the id of the client (if you want) : `server: { adaptor: 'mqtt', host: mqttServer, clientId:"john-doe-000"}`