### PR TITLE
Added opts to Client#publish for qos and retain

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -73,9 +73,12 @@ Adaptor.prototype.subscribe = function() {
  *
  * @param {String} topic which topic to publish to
  * @param {Object|String} data the data to publish to the topic
+ * @param {Object} [opts] - publish options, includes:
+ *    {Number} qos - qos level to publish on
+ *    {Boolean} retain - whether or not to retain the message
  * @return {void}
  * @publish
  */
-Adaptor.prototype.publish = function(topic, data) {
-  this.client.publish(topic, data);
+Adaptor.prototype.publish = function(topic, data, opts) {
+  this.client.publish(topic, data, opts);
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -53,9 +53,12 @@ Driver.prototype.halt = function(callback) {
  * Publishes a new message on the Driver's topic
  *
  * @param {Object|String} data the data to publish to the topic
+ * @param {Object} [opts] - publish options, includes:
+ *    {Number} qos - qos level to publish on
+ *    {Boolean} retain - whether or not to retain the message
  * @return {void}
  * @publish
  */
-Driver.prototype.publish = function(data) {
-  this.connection.publish(this.topic, data);
+Driver.prototype.publish = function(data, opts) {
+  this.connection.publish(this.topic, data, opts);
 };


### PR DESCRIPTION
I needed to set retain on messages sent from cylon-mqtt, so I added optional opts argument to publish methods.

I'd add tests if only I could figure out how to test without depending on an actual broker...