### PR TITLE
Resubscribe adaptor on reconnection

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -63,7 +63,7 @@ Adaptor.prototype.connect = function(callback) {
   this.client.on("reconnect", function() {
     for (var i in this.subscriptions) {
       this.client.subscribe.apply(this.client, this.subscriptions[i]);
-    };
+    }
   }.bind(this));
 
   callback(null);

--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -32,6 +32,12 @@ var Adaptor = module.exports = function Adaptor(opts) {
     this.additionalOpts.protocolVersion = opts.protocolVersion;
   }
 
+  this.subscriptions = [
+    /**
+     * Subscription list is initially empty
+     */
+  ];
+
   this.events = [
 
     /**
@@ -54,6 +60,12 @@ Adaptor.prototype.connect = function(callback) {
     this.emit("message", topic, message);
   }.bind(this));
 
+  this.client.on("reconnect", function() {
+    for (var i in this.subscriptions) {
+      this.client.subscribe.apply(this.client, this.subscriptions[i]);
+    };
+  }.bind(this));
+
   callback(null);
 };
 
@@ -74,6 +86,7 @@ Adaptor.prototype.disconnect = function(callback) {
  */
 Adaptor.prototype.subscribe = function() {
   this.client.subscribe.apply(this.client, arguments);
+  this.subscriptions.push(arguments);
 };
 
 /**

--- a/spec/lib/adaptor.spec.js
+++ b/spec/lib/adaptor.spec.js
@@ -43,6 +43,10 @@ describe("Cylon.Adaptors.Mqtt", function() {
       expect(adaptor.client).to.be.eql(client);
     });
 
+    it("resets list of @subscriptions", function() {
+      expect(adaptor.subscriptions).to.be.eql([]);
+    });
+
     it("attaches a handler to the client", function() {
       expect(client.on).to.be.calledWith("message");
     });
@@ -94,6 +98,13 @@ describe("Cylon.Adaptors.Mqtt", function() {
     it("tells the client to subscribe to a topic", function() {
       expect(client.subscribe).to.be.calledWith("topic");
     });
+
+    it("adds a topic to the list of @subscriptions", function() {
+      expect(adaptor.subscriptions).to.have.length(1);
+      expect(adaptor.subscriptions[0]).to.have.property("0");
+      expect(adaptor.subscriptions[0]["0"]).to.equal("topic");
+    });
+
   });
 
   describe("#publish", function() {


### PR DESCRIPTION
While the underlying MQTT.js module handles reconnects, subscriptions are lost in case of a broker disconnect.

This change resubscribes the adaptor on reconnect, by maintaining a list of subscriptions.

(I don't use the driver interface, so can't test changes in that part.)