### PR TITLE
Issue 9: Allow adaptor to accept MQTT rejectUnauthorized option

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -32,7 +32,7 @@ var Adaptor = module.exports = function Adaptor(opts) {
     this.additionalOpts.protocolVersion = opts.protocolVersion;
   }
 
-  if (opts.rejectUnauthorized != undefined) {
+  if (opts.rejectUnauthorized) {
     this.additionalOpts.rejectUnauthorized = opts.rejectUnauthorized;
   }
     

--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -32,6 +32,11 @@ var Adaptor = module.exports = function Adaptor(opts) {
     this.additionalOpts.protocolVersion = opts.protocolVersion;
   }
 
+  if (opts.rejectUnauthorized != undefined) {
+    this.additionalOpts.rejectUnauthorized = opts.rejectUnauthorized;
+  }
+    
+    
   this.subscriptions = [
     /**
      * Subscription list is initially empty

--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -35,8 +35,8 @@ var Adaptor = module.exports = function Adaptor(opts) {
   if (opts.rejectUnauthorized) {
     this.additionalOpts.rejectUnauthorized = opts.rejectUnauthorized;
   }
-    
-    
+
+
   this.subscriptions = [
     /**
      * Subscription list is initially empty


### PR DESCRIPTION
Allow adaptor to accept MQTT rejectUnauthorized option
e.g.
`connections: {
        mqtt: { adaptor: 'mqtt', host: 'mqtts://myserver:8883', username:'myusername', password:'mypassword', rejectUnauthorized: false }
        }`